### PR TITLE
[Fix] db:setupを削除したentrypoint.shを用意

### DIFF
--- a/api/entrypoint_migration_reset.sh
+++ b/api/entrypoint_migration_reset.sh
@@ -4,5 +4,5 @@ set -e
 # デバッグ用コメント
 echo "Start /api/entrypoint.sh"
 rm -f /myapp/tmp/pids/server.pid
-# bin/setup
+bin/setup
 bundle exec pumactl start


### PR DESCRIPTION
## やったこと
- イメージ再pushでDBが初期化されてしまう対策として、bin/setupをentrypoint.shからコメントアウト