### PR TITLE
[Fix] ゲストユーザー用のメールアドレスのドメインをexample.comに変更

### DIFF
--- a/front/src/reducks/users/operations.js
+++ b/front/src/reducks/users/operations.js
@@ -83,7 +83,7 @@ export const signInGuestUser = () => {
 
     const apiUrl = process.env.REACT_APP_API_V1_URL + '/auth'
 
-    const email = createRandamString(20) + '@guestuser.com'
+    const email = createRandamString(20) + '@example.com'
     const password = createRandamString(30)
 
     const data = {


### PR DESCRIPTION
## やったこと
- ゲストユーザー用のメールアドレスのドメインをexample.comに変更